### PR TITLE
breaking changes to help with test automation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,9 +1,12 @@
 lane :test do
   upload_to_qawolf(
-    file_path: "./fastlane/fastlane-test-app-debug.apk"
+    file_path: "./fastlane/fastlane-test-app-debug.apk",
+    executable_file_basename: "fastlane_test"
   )
   notify_deploy_qawolf(
     deployment_type: "android",
+    sha: false,
+    executable_environment_key: "ANDROID_APP",
     variables: {
       HELLO: "WORLD"
     }

--- a/lib/fastlane/plugin/qawolf/helper/qawolf_helper.rb
+++ b/lib/fastlane/plugin/qawolf/helper/qawolf_helper.rb
@@ -35,8 +35,12 @@ module Fastlane
       # +qawolf_api_key+:: QA Wolf API key
       # +qawolf_base_url+:: QA Wolf API base URL
       # +file_path+:: Path to the file to be uploaded.
-      # +filename+:: Optional filename to use instead of the file's basename.
-      def self.upload_file(qawolf_api_key, qawolf_base_url, file_path, filename = nil)
+      # +executable_file_basename+:: Name to use for the uploaded file without extension
+      def self.upload_file(qawolf_api_key, qawolf_base_url, file_path, executable_file_basename)
+        unless executable_file_basename
+          UI.user_error!("`executable_file_basename` is required")
+        end
+
         file_content = File.open(file_path, "rb")
 
         headers = {
@@ -44,7 +48,8 @@ module Fastlane
           content_type: "application/octet-stream"
         }
 
-        signed_url, run_input_path = get_signed_url(qawolf_api_key, qawolf_base_url, filename || File.basename(file_path))
+        uploaded_filename = "#{executable_file_basename}#{File.extname(file_path)}"
+        signed_url, run_input_path = get_signed_url(qawolf_api_key, qawolf_base_url, uploaded_filename)
 
         RestClient.put(signed_url, file_content, headers)
 

--- a/lib/fastlane/plugin/qawolf/version.rb
+++ b/lib/fastlane/plugin/qawolf/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Qawolf
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/spec/fastlane/actions/notify_deploy_qawolf_action_spec.rb
+++ b/spec/fastlane/actions/notify_deploy_qawolf_action_spec.rb
@@ -2,11 +2,11 @@ require 'webmock/rspec'
 
 describe Fastlane::Actions::NotifyDeployQawolfAction do
   describe "#run" do
-    let(:run_input_path) { "file.apk" }
+    let(:executable_filename) { "file.apk" }
     let(:params) do
       {
         qawolf_api_key: "api_key",
-        run_input_path: run_input_path
+        executable_filename: executable_filename
       }
     end
     let(:deploy_response) do
@@ -32,7 +32,7 @@ describe Fastlane::Actions::NotifyDeployQawolfAction do
     end
 
     context "with no run input path set" do
-      let(:run_input_path) { nil }
+      let(:executable_filename) { nil }
 
       it "fails when no test run is triggered" do
         expect do

--- a/spec/fastlane/actions/upload_to_qawolf_action_spec.rb
+++ b/spec/fastlane/actions/upload_to_qawolf_action_spec.rb
@@ -13,7 +13,7 @@ describe Fastlane::Actions::UploadToQawolfAction do
       {
         qawolf_api_key: "api_key",
         file_path: file_path,
-        filename: nil
+        executable_file_basename: "my_app"
       }
     end
 
@@ -22,7 +22,7 @@ describe Fastlane::Actions::UploadToQawolfAction do
       allow(File).to receive(:open).with(file_path, "rb").and_return('empty file')
 
       url = URI.join(Fastlane::Helper::QawolfHelper::BASE_URL, Fastlane::Helper::QawolfHelper::SIGNED_URL_ENDPOINT)
-      url.query = URI.encode_www_form({ 'file' => params[:filename] || File.basename(file_path) })
+      url.query = URI.encode_www_form({ 'file' => "#{params[:executable_file_basename]}#{File.extname(file_path)}" })
 
       stub_request(:get, url.to_s)
         .to_return(
@@ -47,18 +47,19 @@ describe Fastlane::Actions::UploadToQawolfAction do
       end.to raise_error(FastlaneCore::Interface::FastlaneError)
     end
 
-    context "with filename specified" do
+    context "with no executable_file_basename specified" do
       let(:params) do
         {
           qawolf_api_key: "api_key",
           file_path: file_path,
-          filename: "custom_filename.apk"
+          executable_file_basename: nil
         }
       end
 
-      it "uploads the file with custom filename" do
-        result = described_class.run(params)
-        expect(result).to eq(signed_url_response[:playgroundFileLocation])
+      it "fails to upload" do
+        expect do
+          described_class.run(params)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError)
       end
     end
 


### PR DESCRIPTION
- add required `executable_file_basename` option for the upload plugin
- add optional `executable_environment_key` to customize the `RUN_INPUT_PATH` name for the notify plugin
- rename `run_input_path` option to `executable_filename` for the notify plugin
- update notify plugin to automatically set git branch and commit hash when available