### PR TITLE
add success check for `duplicate_suite_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is a [_fastlane_](https://github.com/fastlane/fastlane) plugin. To 
 
 ```
 # Add this to your Gemfile
-gem "fastlane-plugin-qawolf", git: "https://github.com/qawolf/fastlane-plugin-qawolf", tag: "0.3.0"
+gem "fastlane-plugin-qawolf", git: "https://github.com/qawolf/fastlane-plugin-qawolf", tag: "0.3.1"
 ```
 
 ## About qawolf

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,7 +5,7 @@ lane :test do
   )
   notify_deploy_qawolf(
     deployment_type: "android",
-    sha: false,
+    sha: "random_sha",
     executable_environment_key: "ANDROID_APP",
     variables: {
       HELLO: "WORLD"

--- a/lib/fastlane/plugin/qawolf/helper/qawolf_helper.rb
+++ b/lib/fastlane/plugin/qawolf/helper/qawolf_helper.rb
@@ -84,8 +84,8 @@ module Fastlane
 
         results = response_json["results"]
 
-        failed_trigger = results.find { |result| result["failure_reason"].nil? == false }
-        success_trigger = results.find { |result| result["created_suite_id"].nil? == false }
+        failed_trigger = get_failed_trigger(results)
+        success_trigger = get_success_trigger(results)
 
         if failed_trigger.nil? && success_trigger.nil?
           raise "no matched trigger, reach out to QA Wolf support"
@@ -93,7 +93,15 @@ module Fastlane
           raise failed_trigger["failure_reason"]
         end
 
-        return success_trigger["created_suite_id"]
+        return success_trigger["created_suite_id"] || success_trigger["duplicate_suite_id"]
+      end
+
+      def self.get_failed_trigger(results)
+        results.find { |result| result["failure_reason"].nil? == false }
+      end
+
+      def self.get_success_trigger(results)
+        results.find { |result| result["created_suite_id"].nil? == false || result["duplicate_suite_id"].nil? == false }
       end
 
       # Triggers QA Wolf deploy success webhook to start test runs.

--- a/lib/fastlane/plugin/qawolf/version.rb
+++ b/lib/fastlane/plugin/qawolf/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Qawolf
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end

--- a/spec/fastlane/actions/notify_deploy_qawolf_action_spec.rb
+++ b/spec/fastlane/actions/notify_deploy_qawolf_action_spec.rb
@@ -68,5 +68,19 @@ describe Fastlane::Actions::NotifyDeployQawolfAction do
         end.to raise_error(FastlaneCore::Interface::FastlaneError)
       end
     end
+
+    context "with duplicate suite id set" do
+      let(:deploy_response) do
+        {
+          results: [{ duplicate_suite_id: "duplicate_suite_id" }]
+        }
+      end
+
+      it "returns the duplicate suite id" do
+        result = described_class.run(params)
+        expect(result).to eq(deploy_response[:results][0][:duplicate_suite_id
+        ])
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a fix for the plugin to also consider `duplicate_suite_id` when we've already triggered a run for the provided `sha`.