### PR TITLE
feature: add pull_request_number and merge_request_number to notify_deploy_qawolf

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ lane :build do
         # If configured in QA Wolf, set to GitHub or GitLab as needed
         hosting_service: "GitHub",
 
+        # Optional, the PR/MR number to link test results back to the pull/merge request.
+        # Requires hosting_service: "GitHub" to take effect.
+        pull_request_number: 123,
+        # Requires hosting_service: "GitLab" to take effect.
+        # merge_request_number: 456,
+
         # Optional, defaults to current git commit hash if available. Set to false to skip
         sha: last_git_commit[:commit_hash],
 

--- a/lib/fastlane/plugin/qawolf/actions/notify_deploy_qawolf_action.rb
+++ b/lib/fastlane/plugin/qawolf/actions/notify_deploy_qawolf_action.rb
@@ -30,6 +30,8 @@ module Fastlane
           deployment_url: params[:deployment_url],
           deduplication_key: params[:deduplication_key],
           hosting_service: params[:hosting_service],
+          pull_request_number: params[:pull_request_number],
+          merge_request_number: params[:merge_request_number],
           sha: sha,
           variables: variables.merge({ executable_environment_key => run_input_path(params) })
         }
@@ -122,6 +124,14 @@ module Fastlane
                                        optional: true,
                                        default_value: {},
                                        type: Hash),
+          FastlaneCore::ConfigItem.new(key: :pull_request_number,
+                                       description: "The GitHub pull request number associated with this deployment. Requires `hosting_service: \"GitHub\"` to take effect",
+                                       optional: true,
+                                       type: Integer),
+          FastlaneCore::ConfigItem.new(key: :merge_request_number,
+                                       description: "The GitLab merge request number associated with this deployment. Requires `hosting_service: \"GitLab\"` to take effect",
+                                       optional: true,
+                                       type: Integer),
           FastlaneCore::ConfigItem.new(key: :executable_filename,
                                        env_name: "QAWOLF_EXECUTABLE_FILENAME",
                                        description: "The filename of the executable to use in QA Wolf. Set by the `upload_to_qawolf` action",

--- a/lib/fastlane/plugin/qawolf/helper/qawolf_helper.rb
+++ b/lib/fastlane/plugin/qawolf/helper/qawolf_helper.rb
@@ -74,6 +74,8 @@ module Fastlane
           'deployment_type' => options[:deployment_type],
           'deployment_url' => options[:deployment_url],
           'hosting_service' => options[:hosting_service],
+          'pull_request_number' => options[:pull_request_number],
+          'merge_request_number' => options[:merge_request_number],
           'sha' => options[:sha],
           'variables' => options[:variables]
         }.to_json

--- a/lib/fastlane/plugin/qawolf/version.rb
+++ b/lib/fastlane/plugin/qawolf/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Qawolf
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end


### PR DESCRIPTION
## Overview of Problem
The `notify_deploy_qawolf` Fastlane action had no way to pass a pull request or merge request number when notifying QA Wolf of a deployment. 

## Overview of Changes
Added `pull_request_number` (GitHub) and `merge_request_number` (GitLab) as optional integer parameters to `notify_deploy_qawolf`. Both are forwarded through the options hash in `notify_deploy_qawolf_action.rb` and included in the webhook body built by `qawolf_helper.rb`. README example updated with commented-out usage. Version bumped to `0.4.1`.
